### PR TITLE
add extra_link_args for setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ ext_modules = cythonize(
         library_dirs=[openjtalk_library_path],
         libraries=["openjtalk"],
         extra_compile_args=[],
-        extra_link_args=[],
+        extra_link_args=["-Wl,-rpath=" + openjtalk_library_path],
         language="c++")],
 )
 


### PR DESCRIPTION
Currently the path of open_jtalk is not added in the searching path when
compiling and it causes following error if it's not in the system default or not in LD_LIBRARY_PATH.

```
ImportError: libopenjtalk.so.1.10: cannot open shared object file: No such file or directory
```

`-rpath` option appends optional path for searching in the generated code, so we can avoid this problem without setting LD_LIBRARY_PATH. 