### PR TITLE
Support path that including multibyte-characters

### DIFF
--- a/pyopenjtalk/__init__.py
+++ b/pyopenjtalk/__init__.py
@@ -24,7 +24,7 @@ from .openjtalk import OpenJTalk
 OPEN_JTALK_DICT_DIR = os.environ.get(
     "OPEN_JTALK_DICT_DIR",
     pkg_resources.resource_filename(__name__, "open_jtalk_dic_utf_8-1.11"),
-).encode("ascii")
+).encode("utf-8")
 _DICT_URL = (
     "https://downloads.sourceforge.net/open-jtalk/open_jtalk_dic_utf_8-1.11.tar.gz"
 )
@@ -32,7 +32,7 @@ _DICT_URL = (
 # Default mei_normal.voice for HMM-based TTS
 DEFAULT_HTS_VOICE = pkg_resources.resource_filename(
     __name__, "htsvoice/mei_normal.htsvoice"
-).encode("ascii")
+).encode("utf-8")
 
 # Global instance of OpenJTalk
 _global_jtalk = None
@@ -51,7 +51,7 @@ def _extract_dic():
         f.extractall(path=pkg_resources.resource_filename(__name__, ""))
     OPEN_JTALK_DICT_DIR = pkg_resources.resource_filename(
         __name__, "open_jtalk_dic_utf_8-1.11"
-    ).encode("ascii")
+    ).encode("utf-8")
     os.remove(filename)
 
 


### PR DESCRIPTION
If the PATH of the installation directory of pyopenjtalk contains Japanese characters, the initialization will fail.

```sh
git clone https://github.com/r9y9/pyopenjtalk.git ./日本語を含んだpyopenjtalk
cd 日本語を含んだpyopenjtalk
python -m venv venv
. ./venv/bin/activate
pip install -e .
python -c "import pyopenjtalk" # It will fail at master branch
```

This is not a problem for general use cases, but for use cases such as bundling into a single exe file or specifying where to install a package, the destination directory will be restricted.

I would like to show in test that this works, but could not come up with a good way...