### PR TITLE
create/apply user dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,34 @@ In [3]: pyopenjtalk.g2p("こんにちは", kana=True)
 Out[3]: 'コンニチワ'
 ```
 
+### Create/Apply user dictionary
+
+1. Create a CSV file (e.g. `user.csv`) and write custom words like below:
+
+```csv
+ＧＮＵ,,,1,名詞,一般,*,*,*,*,ＧＮＵ,グヌー,グヌー,2/3,*
+```
+
+2. Call `create_user_dict` to compile the CSV file.
+
+```
+>>> import pyopenjtalk
+>>> pyopenjtalk.create_user_dict("user.csv", "user.dic")
+reading user.csv ... 1
+emitting double-array: 100% |###########################################| 
+
+done!
+```
+
+3. Call `set_user_dict` to apply the user dictionary.
+
+```
+>>> pyopenjtalk.g2p("GNU")
+'j i i e n u y u u'
+>>> pyopenjtalk.set_user_dict("user.dic")
+>>> pyopenjtalk.g2p("GNU")
+'g u n u u'
+```
 
 ## LICENSE
 

--- a/pyopenjtalk/__init__.py
+++ b/pyopenjtalk/__init__.py
@@ -18,7 +18,7 @@ except ImportError:
     raise ImportError("BUG: version.py doesn't exist. Please file a bug report.")
 
 from .htsengine import HTSEngine
-from .openjtalk import OpenJTalk, CreateUserDict
+from .openjtalk import CreateUserDict, OpenJTalk
 
 # Dictionary directory
 # defaults to the package directory where the dictionary will be automatically downloaded
@@ -168,6 +168,7 @@ def run_frontend(text, verbose=0):
         _global_jtalk = OpenJTalk(dn_mecab=OPEN_JTALK_DICT_DIR)
     return _global_jtalk.run_frontend(text, verbose)
 
+
 def create_user_dict(path, out_path):
     """Create user dictionary
 
@@ -182,6 +183,7 @@ def create_user_dict(path, out_path):
         raise ValueError("no such file or directory: %s" % path)
     CreateUserDict(OPEN_JTALK_DICT_DIR, path.encode("utf-8"), out_path.encode("utf-8"))
 
+
 def set_user_dict(path):
     """Apply user dictionary
 
@@ -193,4 +195,6 @@ def set_user_dict(path):
         _lazy_init()
     if not exists(path):
         raise ValueError("no such file or directory: %s" % path)
-    _global_jtalk = OpenJTalk(dn_mecab=OPEN_JTALK_DICT_DIR, user_mecab=path.encode("utf-8"))
+    _global_jtalk = OpenJTalk(
+        dn_mecab=OPEN_JTALK_DICT_DIR, user_mecab=path.encode("utf-8")
+    )

--- a/pyopenjtalk/__init__.py
+++ b/pyopenjtalk/__init__.py
@@ -18,7 +18,7 @@ except ImportError:
     raise ImportError("BUG: version.py doesn't exist. Please file a bug report.")
 
 from .htsengine import HTSEngine
-from .openjtalk import OpenJTalk
+from .openjtalk import OpenJTalk, CreateUserDict
 
 # Dictionary directory
 # defaults to the package directory where the dictionary will be automatically downloaded
@@ -167,3 +167,30 @@ def run_frontend(text, verbose=0):
         _lazy_init()
         _global_jtalk = OpenJTalk(dn_mecab=OPEN_JTALK_DICT_DIR)
     return _global_jtalk.run_frontend(text, verbose)
+
+def create_user_dict(path, out_path):
+    """Create user dictionary
+
+    Args:
+        path (str): path to user csv
+        out_path (str): path to output dictionary
+    """
+    global _global_jtalk
+    if _global_jtalk is None:
+        _lazy_init()
+    if not exists(path):
+        raise ValueError("no such file or directory: %s" % path)
+    CreateUserDict(OPEN_JTALK_DICT_DIR, path.encode("utf-8"), out_path.encode("utf-8"))
+
+def set_user_dict(path):
+    """Apply user dictionary
+
+    Args:
+        path (str): path to user dictionary
+    """
+    global _global_jtalk
+    if _global_jtalk is None:
+        _lazy_init()
+    if not exists(path):
+        raise ValueError("no such file or directory: %s" % path)
+    _global_jtalk = OpenJTalk(dn_mecab=OPEN_JTALK_DICT_DIR, user_mecab=path.encode("utf-8"))

--- a/pyopenjtalk/openjtalk/mecab.pxd
+++ b/pyopenjtalk/openjtalk/mecab.pxd
@@ -16,3 +16,14 @@ cdef extern from "mecab.h":
     char **Mecab_get_feature(Mecab *m)
     cdef int Mecab_refresh(Mecab *m)
     cdef int Mecab_clear(Mecab *m)
+    cdef int mecab_dict_index(int argc, char **argv)
+
+cdef extern from "mecab.h" namespace "MeCab":
+    cdef cppclass Tagger:
+        pass
+    cdef cppclass Lattice:
+        pass
+    cdef cppclass Model:
+        Tagger *createTagger()
+        Lattice *createLattice()
+    cdef Model *createModel(int argc, char **argv)


### PR DESCRIPTION
Added some functions to support custom words.

By using this feature, we can build and load a user dictionary from python side.

Example:

```
>>> import pyopenjtalk
>>> pyopenjtalk.create_user_dict("user.csv", "user.dic")
reading user.csv ... 1
emitting double-array: 100% |###########################################| 
done!
>>> pyopenjtalk.g2p("GNU")
'j i i e n u y u u'
>>> pyopenjtalk.set_user_dict("user.dic")
>>> pyopenjtalk.g2p("GNU")
'g u n u u'
```

The format of `user.csv` above is same as that of the input csv of `mecab-dict-index` binary.