### PR TITLE
Workaround the installation issue #27

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "wheel",
-    "setuptools",
+    "setuptools<v60.0",
     "cython>=0.21.0",
     "numpy<v1.20.0",
 ]


### PR DESCRIPTION
Not sure about the exact root cause, but the error messages suggested that there are issues with setuptools/pip. I can confirm we can fix the issue by changing the build-time setuptools requirement to <v60.0.

At least v59.8.0 should work.
https://github.com/pypa/setuptools/releases/tag/v59.8.0

Fixes #27