### PR TITLE
Use oldest-supported-numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "wheel",
     "setuptools<v60.0",
     "cython>=0.28.0",
-    "numpy>=1.20.0",
+    "oldest-supported-numpy",
 ]
 
 [tool.pysen]


### PR DESCRIPTION
Using [oldest-supported-numpy](https://github.com/scipy/oldest-supported-numpy) to improve numpy's ABI compatibility.

- fix #42 

Reference
- https://numpy.org/doc/stable/dev/depending_on_numpy.html#build-time-dependency

#### note
https://github.com/r9y9/pyopenjtalk/blob/d6ff4377fae6bb6feb325df892736b914dd00c91/setup.py#L279

It may be possible to downgrade.
