### PR TITLE
ADD: build-backend key to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
 requires = [
-    "wheel",
     "setuptools<v60.0",
     "cython>=0.28.0",
     "oldest-supported-numpy",
 ]
+build-backend = "setuptools.build_meta"
 
 [tool.pysen]
 version = "0.10.2"


### PR DESCRIPTION
Add build-backend key to pyproject.toml.
This makes building easier as MSVC is automatically detected on Windows.

Using MSVC requires setting complex environment variables or using developer command prompt shortcuts, which many people seem to forget.
https://learn.microsoft.com/cpp/build/building-on-the-command-line#path_and_environment
If MSVC is automatically detected, such labor will be eliminated.

And I also removed unnecessary wheels from requires.

https://setuptools.pypa.io/en/latest/userguide/quickstart.html#basic-use
>Note
>Historically this documentation has unnecessarily listed wheel in the requires list, and many projects still do that. This is not recommended. The backend automatically adds wheel dependency when it is required, and listing it explicitly causes it to be unnecessarily required for source distribution builds. You should only include wheel in requires if you need to explicitly access it during build time (e.g. if your project needs a setup.py script that imports wheel).