### PR TITLE
ENH: Fix requires numpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,8 @@
 requires = [
     "setuptools<v60.0",
     "cython>=0.28.0,<3.0.0",
-    "oldest-supported-numpy",
+    "numpy>=1.25.0; python_version>='3.9'",
+    "oldest-supported-numpy; python_version<'3.9'",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
- ref https://numpy.org/doc/stable/dev/depending_on_numpy.html#build-time-dependency

I add oldest-supported-numpy in #45 .
But numpy1.25 added backward compatibility for C-API.
>Note
>
>Before NumPy 1.25, the NumPy C-API was not backwards compatible. This means that when compiling with a NumPy version earlier than 1.25 you have to compile with the oldest version you wish to support. This can be done by using [oldest-supported-numpy](https://github.com/scipy/oldest-supported-numpy/). Please see the [NumPy 1.24 documentation](https://numpy.org/doc/1.24/dev/depending_on_numpy.html).

In addition to that, a description about Numpy 2 was added.
>Note
>
>At the time of NumPy 1.25, NumPy 2.0 is expected to be the next release of NumPy. The NumPy 2.0 release is expected to require a different pin, since NumPy 2+ will be needed in order to be compatible with both NumPy 1.x and 2.x.

This PR will change to use the latest Numpy in Python 3.9 or later environments that support Numpy 1.25 or later.
I think this makes it more compatible with Numpy 2.