### PR TITLE
ENH: add build-system requires cmake

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 requires = [
     "setuptools<v60.0",
     "cython>=0.28.0,<3.0.0",
+    "cmake",
     "numpy>=1.25.0; python_version>='3.9'",
     "oldest-supported-numpy; python_version<'3.9'",
 ]


### PR DESCRIPTION
Add cmake to your build-system requirements.

This solves Build fails if pip's cmake is installed.
And it will be able to build even if cmake is not installed.

- fix #30 
- fix #33 
- fix #34 
- fix #50 
