### PR TITLE
ENH: Remove Cython from install_requires.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e ".[lint]"
+        pip install -e ".[dev]"
     - name: Lint with pysen
       run: |
         pysen run lint

--- a/setup.py
+++ b/setup.py
@@ -277,7 +277,6 @@ setup(
     cmdclass=cmdclass,
     install_requires=[
         "numpy >= 1.20.0",
-        "cython >= " + min_cython_ver + ",<3.0.0",
         "six",
         "tqdm",
     ],
@@ -291,7 +290,8 @@ setup(
             "ipython",
             "jupyter",
         ],
-        "lint": [
+        "dev": [
+            "cython >= " + min_cython_ver + ",<3.0.0",
             "pysen",
             "types-setuptools",
             "mypy<=0.910",


### PR DESCRIPTION
Cython is not required at runtime.
So I think it should be removed from install_requires.

However, I think that it is necessary at the time of development, so change it as follows.
1. Change lint of extras_require to dev.
2. Move install_requires Cython to dev.