### PR TITLE
Checking cmake is in the system path for windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,36 @@ else:
         raise RuntimeError("Cython is required to generate C++ code")
 
 
+
+
+def check_cmake_in_path():
+    try:
+        result = subprocess.run(['cmake', '--version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        if result.returncode == 0:
+            # CMake is in the system path
+            return True, result.stdout.strip()
+        else:
+            # CMake is not in the system path
+            return False, None
+    except FileNotFoundError:
+        # CMake command not found
+        return False, None
+
+if os.name == 'nt':  # Check if the OS is Windows
+    # Check if CMake is in the system path
+    cmake_found, cmake_version = check_cmake_in_path()
+
+    if cmake_found:
+        print(f"CMake is in the system path. Version: {cmake_version}")
+    else:
+        raise SystemError("CMake is not found in the system path. Make sure CMake is installed and in the system path.")
+
+
+
+
+
+
+
 # Workaround for `distutils.spawn` problem on Windows python < 3.9
 # See details: [bpo-39763: distutils.spawn now uses subprocess (GH-18743)]
 # (https://github.com/python/cpython/commit/1ec63b62035e73111e204a0e03b83503e1c58f2e)


### PR DESCRIPTION
From time to time, people on windows suffer compiling error, file not found.  But not showing what files, so I add a checking of the cmake in the begging since the cmake is required but not necessary exist on windows sys path.