### PR TITLE
ENH: support python3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
-    "setuptools<v60.0",
+    "setuptools>=66.1.0; python_version>='3.12'",
+    "setuptools<v60.0; python_version<'3.12'",
     "cython>=0.28.0",
     "cmake",
     "numpy>=1.25.0; python_version>='3.9'",


### PR DESCRIPTION
Fix install error on Python3.12

I was unable to reproduce the problem in #27, so I left `setuptools<v60.0` as is.