### PR TITLE
FIX: remove legacy API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -313,8 +313,8 @@ setup(
     ext_modules=ext_modules,
     cmdclass=cmdclass,
     install_requires=[
+        "importlib_resources; python_version<'3.9'",
         "numpy >= 1.20.0",
-        "six",
         "tqdm",
     ],
     tests_require=["nose", "coverage"],


### PR DESCRIPTION
Remove legacy APIs from `__init__.py`.

- Replace pkg_resources with importlib-resources.
ref: https://importlib-resources.readthedocs.io/en/latest/migration.html
This removes the implicit setuptools dependency.
I think it is important for Python3.12 because setuptools may not be installed by default.
ref: https://docs.python.org/3/whatsnew/3.12.html
> [gh-95299](https://github.com/python/cpython/issues/95299): Do not pre-install setuptools in virtual environments created with [venv](https://docs.python.org/ja/3/library/venv.html#module-venv). This means that distutils, setuptools, pkg_resources, and easy_install will no longer available by default; to access these run pip install setuptools in the [activated](https://docs.python.org/ja/3/library/venv.html#venv-explanation) virtual environment.

- Remove `six`.

- Replace urlretrieve with urlopen.
There is no name to give `desc` since it uses a `TemporaryFile()`.