### PR TITLE
BLD: remove distutil from setup.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [build-system]
 requires = [
     "setuptools>=66.1.0; python_version>='3.12'",
-    "setuptools<v60.0; python_version<'3.12'",
+    "setuptools>=60.0.0; sys.platform=='win32'",
+    "setuptools<v60.0; python_version<'3.12' and sys.platform!='win32'",
     "cython>=0.28.0",
     "cmake",
     "numpy>=1.25.0; python_version>='3.9'",

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,13 @@
 import os
 import subprocess
 import sys
-from distutils.errors import DistutilsExecError
-from distutils.spawn import spawn
-from distutils.version import LooseVersion
 from glob import glob
 from itertools import chain
 from os.path import exists, join
 from subprocess import run
 
 import numpy as np
+import setuptools.command.build_ext
 import setuptools.command.build_py
 import setuptools.command.develop
 from setuptools import Extension, find_packages, setup
@@ -18,57 +16,30 @@ platform_is_windows = sys.platform == "win32"
 
 version = "0.3.4-dev"
 
-min_cython_ver = "0.21.0"
-try:
-    import Cython
-
-    ver = Cython.__version__
-    _CYTHON_INSTALLED = ver >= LooseVersion(min_cython_ver)
-except ImportError:
-    _CYTHON_INSTALLED = False
-
-
 msvc_extra_compile_args_config = [
     "/source-charset:utf-8",
     "/execution-charset:utf-8",
 ]
 
-try:
-    if not _CYTHON_INSTALLED:
-        raise ImportError("No supported version of Cython installed.")
-    from Cython.Distutils import build_ext
 
-    cython = True
-except ImportError:
-    cython = False
+def msvc_extra_compile_args(compile_args):
+    cas = set(compile_args)
+    xs = filter(lambda x: x not in cas, msvc_extra_compile_args_config)
+    return list(chain(compile_args, xs))
 
-if cython:
-    ext = ".pyx"
 
-    def msvc_extra_compile_args(compile_args):
-        cas = set(compile_args)
-        xs = filter(lambda x: x not in cas, msvc_extra_compile_args_config)
-        return list(chain(compile_args, xs))
+class custom_build_ext(setuptools.command.build_ext.build_ext):
+    def build_extensions(self):
+        compiler_type_is_msvc = self.compiler.compiler_type == "msvc"
+        for entry in self.extensions:
+            if compiler_type_is_msvc:
+                entry.extra_compile_args = msvc_extra_compile_args(
+                    entry.extra_compile_args
+                    if hasattr(entry, "extra_compile_args")
+                    else []
+                )
 
-    class custom_build_ext(build_ext):
-        def build_extensions(self):
-            compiler_type_is_msvc = self.compiler.compiler_type == "msvc"
-            for entry in self.extensions:
-                if compiler_type_is_msvc:
-                    entry.extra_compile_args = msvc_extra_compile_args(
-                        entry.extra_compile_args
-                        if hasattr(entry, "extra_compile_args")
-                        else []
-                    )
-
-            build_ext.build_extensions(self)
-
-    cmdclass = {"build_ext": custom_build_ext}
-else:
-    ext = ".cpp"
-    cmdclass = {}
-    if not os.path.exists(join("pyopenjtalk", "openjtalk" + ext)):
-        raise RuntimeError("Cython is required to generate C++ code")
+        setuptools.command.build_ext.build_ext.build_extensions(self)
 
 
 def check_cmake_in_path():
@@ -106,71 +77,6 @@ if os.name == "nt":  # Check if the OS is Windows
                           is installed and in the system \
                           path."
         )
-
-
-# Workaround for `distutils.spawn` problem on Windows python < 3.9
-# See details: [bpo-39763: distutils.spawn now uses subprocess (GH-18743)]
-# (https://github.com/python/cpython/commit/1ec63b62035e73111e204a0e03b83503e1c58f2e)
-def test_quoted_arg_change():
-    child_script = """
-import os
-import sys
-if len(sys.argv) > 5:
-    try:
-        os.makedirs(sys.argv[1], exist_ok=True)
-        with open(sys.argv[2], mode=sys.argv[3], encoding=sys.argv[4]) as fd:
-            fd.write(sys.argv[5])
-    except OSError:
-        pass
-"""
-
-    try:
-        # write
-        package_build_dir = "build"
-        file_name = join(package_build_dir, "quoted_arg_output")
-        output_mode = "w"
-        file_encoding = "utf8"
-        arg_value = '"ARG"'
-
-        spawn(
-            [
-                sys.executable,
-                "-c",
-                child_script,
-                package_build_dir,
-                file_name,
-                output_mode,
-                file_encoding,
-                arg_value,
-            ]
-        )
-
-        # read
-        with open(file_name, mode="r", encoding=file_encoding) as fd:
-            return fd.readline() != arg_value
-    except (DistutilsExecError, TypeError):
-        return False
-
-
-def escape_string_macro_arg(s):
-    return s.replace("\\", "\\\\").replace('"', '\\"')
-
-
-def escape_macro_element(x):
-    (k, arg) = x
-    return (k, escape_string_macro_arg(arg)) if type(arg) == str else x
-
-
-def escape_macros(macros):
-    return list(map(escape_macro_element, macros))
-
-
-custom_define_macros = (
-    escape_macros
-    if platform_is_windows and test_quoted_arg_change()
-    else (lambda macros: macros)
-)
-
 
 # open_jtalk sources
 src_top = join("lib", "open_jtalk", "src")
@@ -215,21 +121,19 @@ for s in [
 ext_modules = [
     Extension(
         name="pyopenjtalk.openjtalk",
-        sources=[join("pyopenjtalk", "openjtalk" + ext)] + all_src,
+        sources=[join("pyopenjtalk", "openjtalk.pyx")] + all_src,
         include_dirs=[np.get_include()] + include_dirs,
         extra_compile_args=[],
         extra_link_args=[],
         language="c++",
-        define_macros=custom_define_macros(
-            [
-                ("HAVE_CONFIG_H", None),
-                ("DIC_VERSION", 102),
-                ("MECAB_DEFAULT_RC", '"dummy"'),
-                ("PACKAGE", '"open_jtalk"'),
-                ("VERSION", '"1.10"'),
-                ("CHARSET_UTF_8", None),
-            ]
-        ),
+        define_macros=[
+            ("HAVE_CONFIG_H", None),
+            ("DIC_VERSION", "102"),
+            ("MECAB_DEFAULT_RC", '"dummy"'),
+            ("PACKAGE", '"open_jtalk"'),
+            ("VERSION", '"1.10"'),
+            ("CHARSET_UTF_8", None),
+        ],
     )
 ]
 
@@ -239,17 +143,15 @@ all_htsengine_src = glob(join(htsengine_src_top, "lib", "*.c"))
 ext_modules += [
     Extension(
         name="pyopenjtalk.htsengine",
-        sources=[join("pyopenjtalk", "htsengine" + ext)] + all_htsengine_src,
+        sources=[join("pyopenjtalk", "htsengine.pyx")] + all_htsengine_src,
         include_dirs=[np.get_include(), join(htsengine_src_top, "include")],
         extra_compile_args=[],
         extra_link_args=[],
         libraries=["winmm"] if platform_is_windows else [],
         language="c++",
-        define_macros=custom_define_macros(
-            [
-                ("AUDIO_PLAY_NONE", None),
-            ]
-        ),
+        define_macros=[
+            ("AUDIO_PLAY_NONE", None),
+        ],
     )
 ]
 
@@ -291,10 +193,6 @@ class develop(setuptools.command.develop.develop):
         setuptools.command.develop.develop.run(self)
 
 
-cmdclass["build_py"] = build_py
-cmdclass["develop"] = develop
-
-
 with open("README.md", "r", encoding="utf8") as fd:
     long_description = fd.read()
 
@@ -311,7 +209,7 @@ setup(
     packages=find_packages(),
     package_data={"": ["htsvoice/*"]},
     ext_modules=ext_modules,
-    cmdclass=cmdclass,
+    cmdclass={"build_ext": custom_build_ext, "build_py": build_py, "develop": develop},
     install_requires=[
         "numpy >= 1.20.0",
         "six",
@@ -328,7 +226,7 @@ setup(
             "jupyter",
         ],
         "dev": [
-            "cython >= " + min_cython_ver + ",<3.0.0",
+            "cython>=0.28.0",
             "pysen",
             "types-setuptools",
             "mypy<=0.910",


### PR DESCRIPTION
Remove distutil from setup.py

- Remove `distutils.version.LooseVersion`.

  Cython version checking is done in `pyproject.toml` so there is no need to check it.

  The ability to build if you have a `.cpp` files even if Cython is not installed will continue to be supported.
  ref: https://setuptools.pypa.io/en/latest/userguide/ext_modules.html#distributing-extensions-compiled-with-cython

- Remove `distutils.spawn.spawn` and `distutils.errors.DistutilsExecError`.

  https://github.com/r9y9/pyopenjtalk/blob/48dd78cafc954c8aff26a64b5c7ed54a8d0a3fb9/setup.py#L111-L172
  This bug seems to have been patched by `setuptools>=60.0.0`.
  Therefore, this code can be made unnecessary by changing the version of setuptools only on Windows.

  It may be better to upgrade the version of setuptools on other OS as well.
  However, since I can't reproduce #27 , So I leave it as is.