### PR TITLE
MAINT: Bump up `actions/checkout` `actions/setup-python`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e ".[dev]"
     - name: Lint with pysen
+      if: ${{ matrix.python-version != '3.7' }}
       run: |
         pysen run lint
     - name: Test with pytest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,11 +30,11 @@ jobs:
             python-version: 3.9
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
`actions/setup-python@v1` is not support macos-latest (arm64).
So bump up to  `actions/setup-python@v5`.
And bump up to `actions/checkout@v4`.