### PR TITLE
FIX: Fix or suppress the warning.

### DIFF
--- a/pyopenjtalk/htsengine.pyx
+++ b/pyopenjtalk/htsengine.pyx
@@ -1,6 +1,7 @@
 # coding: utf-8
 # cython: boundscheck=True, wraparound=True
 # cython: c_string_type=unicode, c_string_encoding=ascii
+# cython: language_level=3
 
 import numpy as np
 
@@ -19,7 +20,7 @@ from .htsengine cimport (
     HTS_Engine_get_generated_speech, HTS_Engine_get_nsamples
 )
 
-cdef class HTSEngine(object):
+cdef class HTSEngine:
     """HTSEngine
 
     Args:

--- a/pyopenjtalk/htsengine/__init__.pxd
+++ b/pyopenjtalk/htsengine/__init__.pxd
@@ -1,4 +1,5 @@
 # distutils: language = c++
+# cython: language_level=3
 
 
 cdef extern from "HTS_engine.h":

--- a/pyopenjtalk/openjtalk.pyx
+++ b/pyopenjtalk/openjtalk.pyx
@@ -1,6 +1,7 @@
 # coding: utf-8
 # cython: boundscheck=True, wraparound=True
 # cython: c_string_type=unicode, c_string_encoding=ascii
+# cython: language_level=3
 
 import numpy as np
 
@@ -151,7 +152,7 @@ cdef inline int Mecab_load_with_userdic(Mecab *m, char* dicdir, char* userdic):
     return 1
 
 
-cdef class OpenJTalk(object):
+cdef class OpenJTalk:
     """OpenJTalk
 
     Args:

--- a/pyopenjtalk/openjtalk/__init__.pxd
+++ b/pyopenjtalk/openjtalk/__init__.pxd
@@ -1,0 +1,1 @@
+# cython: language_level=3

--- a/pyopenjtalk/openjtalk/jpcommon.pxd
+++ b/pyopenjtalk/openjtalk/jpcommon.pxd
@@ -1,4 +1,5 @@
 # distutils: language = c++
+# cython: language_level=3
 
 from libc.stdio cimport FILE
 

--- a/pyopenjtalk/openjtalk/mecab.pxd
+++ b/pyopenjtalk/openjtalk/mecab.pxd
@@ -1,4 +1,5 @@
 # distutils: language = c++
+# cython: language_level=3
 
 cdef extern from "mecab.h":
     cdef cppclass Mecab:

--- a/pyopenjtalk/openjtalk/mecab2njd.pxd
+++ b/pyopenjtalk/openjtalk/mecab2njd.pxd
@@ -1,4 +1,5 @@
 # distutils: language = c++
+# cython: language_level=3
 
 from .njd cimport NJD
 

--- a/pyopenjtalk/openjtalk/njd.pxd
+++ b/pyopenjtalk/openjtalk/njd.pxd
@@ -1,4 +1,5 @@
 # distutils: language = c++
+# cython: language_level=3
 
 from libc.stdio cimport FILE
 

--- a/pyopenjtalk/openjtalk/njd2jpcommon.pxd
+++ b/pyopenjtalk/openjtalk/njd2jpcommon.pxd
@@ -1,4 +1,5 @@
 # distutils: language = c++
+# cython: language_level=3
 
 from .jpcommon cimport JPCommon
 from .njd cimport NJD

--- a/pyopenjtalk/openjtalk/text2mecab.pxd
+++ b/pyopenjtalk/openjtalk/text2mecab.pxd
@@ -1,4 +1,5 @@
 # distutils: language = c++
+# cython: language_level=3
 
 cdef extern from "text2mecab.h":
     void text2mecab(char *output, const char *input)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=64",
     "setuptools_scm>=8",
-    "cython>=3",
+    "cython>=0.28.0",
     "cmake",
     "numpy>=1.25.0; python_version>='3.9'",
     "oldest-supported-numpy; python_version<'3.9'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=64",
     "setuptools_scm>=8",
-    "cython>=0.28.0",
+    "cython>=3",
     "cmake",
     "numpy>=1.25.0; python_version>='3.9'",
     "oldest-supported-numpy; python_version<'3.9'",
@@ -52,7 +52,7 @@ docs = [
     "jupyter",
 ]
 dev = [
-    "cython>=0.28.0",
+    "cython>=3",
     "pysen",
     "types-setuptools",
     "mypy<=0.910",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=64",
     "setuptools_scm>=8",
-    "cython>=0.28.0",
+    "cython>=0.29.16",
     "cmake",
     "numpy>=1.25.0; python_version>='3.9'",
     "oldest-supported-numpy; python_version<'3.9'",
@@ -52,7 +52,7 @@ docs = [
     "jupyter",
 ]
 dev = [
-    "cython>=3",
+    "cython>=0.29.16",
     "pysen",
     "types-setuptools",
     "mypy<=0.910",

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,18 @@ def msvc_extra_compile_args(compile_args):
     return list(chain(compile_args, xs))
 
 
+msvc_define_macros_config = [
+    ("_CRT_NONSTDC_NO_WARNINGS", None),
+    ("_CRT_SECURE_NO_WARNINGS", None),
+]
+
+
+def msvc_define_macros(macros):
+    mns = set([i[0] for i in macros])
+    xs = filter(lambda x: x[0] not in mns, msvc_define_macros_config)
+    return list(chain(macros, xs))
+
+
 class custom_build_ext(setuptools.command.build_ext.build_ext):
     def build_extensions(self):
         compiler_type_is_msvc = self.compiler.compiler_type == "msvc"
@@ -32,6 +44,9 @@ class custom_build_ext(setuptools.command.build_ext.build_ext):
                     entry.extra_compile_args
                     if hasattr(entry, "extra_compile_args")
                     else []
+                )
+                entry.define_macros = msvc_define_macros(
+                    entry.define_macros if hasattr(entry, "define_macros") else []
                 )
 
         setuptools.command.build_ext.build_ext.build_extensions(self)
@@ -148,6 +163,7 @@ ext_modules += [
         language="c++",
         define_macros=[
             ("AUDIO_PLAY_NONE", None),
+            ("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION"),
         ],
     )
 ]


### PR DESCRIPTION
Fixes or suppresses warnings that occur when building native code that can be resolved with pyopenjtalk.
This makes it easier to understand the cause of the error.

There are still a lot of warnings, but I think they should be fixed in the `OpenJTalk`/`HTSEngine` repository.