### PR TITLE
ENH: Migrate CI to use cibuildwheel for building wheels

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,10 +51,13 @@ jobs:
         pip install pytest
         pytest
 
-  build-for-publish:
+  build-wheels-for-publish:
     name: Build distribution 📦
-    runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags')"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-latest-arm, windows-latest, macos-latest]
     needs: test
     steps:
       - uses: actions/checkout@v4
@@ -68,16 +71,46 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade build
+          python -m pip install cibuildwheel==2.16.2
 
-      - name: Build a source tarball and wheel
-        run: python -m build .
+      - name: Build wheels
+        env:
+          CIBW_SKIP: "pp* *-musllinux_*"
+        run: python -m cibuildwheel --output-dir wheelhouse
 
       - name: Store the distribution packages
         uses: actions/upload-artifact@v4
         with:
-          name: python-package-distributions
-          # NOTE: for now upload sdist only to prevent errors like unsupported platform tag 'linux_x86_64'.
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./wheelhouse/*.whl
+
+  build-sdist-for-publish:
+    name: Build source distribution 📦
+    if: "startsWith(github.ref, 'refs/tags')"
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Install build tool
+        run: python -m pip install sdist
+      - name: Build source distribution
+        run: python setup.py sdist
+      - name: Upload sdist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist-artifact
           path: dist/*.tar.gz
 
   publish-to-pypi:
@@ -85,7 +118,8 @@ jobs:
       Publish Python 🐍 distribution 📦 to PyPI
     if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
     needs:
-    - build-for-publish
+    - build-wheels-for-publish
+    - build-sdist-for-publish
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -96,12 +130,20 @@ jobs:
       - name: Download all the dists
         uses: actions/download-artifact@v4
         with:
-          name: python-package-distributions
-          path: dist/
+          # unpacks all CIBW artifacts into dist/
+          path: dist
+          pattern: cibw-wheels-*
+          merge-multiple: true
+      - name: Download sdist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: sdist-artifact
+          path: dist
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: true
+          password: ${{ secrets.PYPI_TOKEN }}
 
   # NOTE: for testing purposes only
   # publish-to-testpypi:


### PR DESCRIPTION
Hello,

PyOpenJTalk is a wonderful library, and I have been using it for small robots and IoT modules.

This PR introduces a GitHub Action to build and release wheels to the PyPI repository. By providing pre-built wheel files, users can install PyOpenJTalk without needing to build it, making it more accessible for low-performance PCs.

For building wheels, I have used cibuildwheel, a library designed for this purpose:
https://github.com/pypa/cibuildwheel

If you have any comments or suggestions for modifications, I would be happy to address them. I hope this functionality can be merged into the repository so that wheel releases can be included in future updates.