### PR TITLE
update open_jtalk for #99

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,11 +101,7 @@ if not exists(join(src_top, "mecab", "src", "config.h")):
     os.makedirs(build_dir, exist_ok=True)
     os.chdir(build_dir)
 
-    # NOTE: The wrapped OpenJTalk does not depend on HTS_Engine,
-    # but since HTSEngine is included in CMake's dependencies, it refers to a dummy path.
-    r = subprocess.run(
-        ["cmake", "..", "-DHTS_ENGINE_INCLUDE_DIR=.", "-DHTS_ENGINE_LIB=dummy"]
-    )
+    r = subprocess.run(["cmake", ".."])
     r.check_returncode()
     os.chdir(cwd)
 


### PR DESCRIPTION
includes fixes for cmake 4.0 that drops compatibility with older cmakes that do not specify cmake 3.5 as upper bound in cmake_minimum_version

fixes #99 