### PR TITLE
FIX: fix warning `release.sh`.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include pyopenjtalk/version.py
-exclude .gitignore .gitmodules .travis.yml release.sh tox.ini
+exclude .gitignore .gitmodules .travis.yml tox.ini
 prune .github/*
 prune docs/**
 recursive-include lib *.cpp *.c *.h README COPYING CMakeLists.txt *.in


### PR DESCRIPTION
fix warning `warning: no previously-included files found matching 'release.sh'`

This was caused by deleting `release.sh` in #95.
