### PR TITLE
ENH: Add support for unsetting a dictionary once set.

### DIFF
--- a/pyopenjtalk/__init__.py
+++ b/pyopenjtalk/__init__.py
@@ -274,12 +274,15 @@ def update_global_jtalk_with_user_dict(path):
     Note that this will change the global state of the openjtalk module.
 
     Args:
-        path (str): path to user dictionary
+        path (str | None): path to user dictionary.
+          If None, Update global openjtalk instance without the user dictionary.
     """
+    if path is None:
+        path = ""
+    elif not exists(path):
+        raise FileNotFoundError("no such file or directory: %s" % path)
     global _global_jtalk
     with _global_jtalk():
-        if not exists(path):
-            raise FileNotFoundError("no such file or directory: %s" % path)
         _global_jtalk = _global_instance_manager(
             instance=OpenJTalk(
                 dn_mecab=OPEN_JTALK_DICT_DIR, userdic=path.encode("utf-8")

--- a/tests/test_openjtalk.py
+++ b/tests/test_openjtalk.py
@@ -89,10 +89,11 @@ def test_g2p_phone():
 
 
 def test_userdic():
-    for text, expected in [
+    parameter = [
         ("nnmn", "n a n a m i N"),
         ("GNU", "g u n u u"),
-    ]:
+    ]
+    for text, expected in parameter:
         p = pyopenjtalk.g2p(text)
         assert p != expected
 
@@ -106,12 +107,15 @@ def test_userdic():
     pyopenjtalk.mecab_dict_index(f.name, user_dic)
     pyopenjtalk.update_global_jtalk_with_user_dict(user_dic)
 
-    for text, expected in [
-        ("nnmn", "n a n a m i N"),
-        ("GNU", "g u n u u"),
-    ]:
+    for text, expected in parameter:
         p = pyopenjtalk.g2p(text)
         assert p == expected
+
+    pyopenjtalk.update_global_jtalk_with_user_dict(None)
+
+    for text, expected in parameter:
+        p = pyopenjtalk.g2p(text)
+        assert p != expected
 
 
 def test_multithreading():


### PR DESCRIPTION
Add support for unsetting a dictionary once set.

It is difficult to do the same because it is not possible to create an empty user dictionary.
It would also be nice to be able to do this since Windows has a limitation that you cannot delete an open dictionary.