### PR TITLE
FIX: Fix build failure issue with Python 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = [
     "setuptools>=64",
     "setuptools_scm>=8",
     "cython>=0.29.16",
+    "cython<3.1.0; python_version<'3.9'",
     "cmake",
     "numpy>=1.25.0; python_version>='3.9'",
     "oldest-supported-numpy; python_version<'3.9'",


### PR DESCRIPTION
Build fails with Python 3.8.
There seems to be a problem with the combination of Cython >= 3.1.0 and numpy < 1.19.

This fix works around the issue by changing Python 3.8 to build with Cython < 3.1.0.

NOTE:
If you want to upgrade the version of Numpy used during the build, you need to specify the version of Numpy to use for each platform.
This seems like a hassle.